### PR TITLE
Time Cluster Addition and Colour Coding of Straw Hits

### DIFF
--- a/examples/helix_example.fcl
+++ b/examples/helix_example.fcl
@@ -20,6 +20,7 @@ physics.analyzers.REveEventDisplay.filler.addKalSeeds : true
 physics.analyzers.REveEventDisplay.filler.addClusters : true
 physics.analyzers.REveEventDisplay.filler.addHits : true
 physics.analyzers.REveEventDisplay.filler.addTimeClusters : true
+physics.analyzers.REveEventDisplay.filler.addTrkHits : true
 physics.analyzers.REveEventDisplay.filler.addCosmicTrackSeeds : false
 physics.analyzers.REveEventDisplay.filler.addMCTraj : false
 physics.EndPath  : [ @sequence::REveDis.seqBase] 

--- a/examples/helix_example.fcl
+++ b/examples/helix_example.fcl
@@ -19,6 +19,7 @@ physics.analyzers.REveEventDisplay.showCRV : true
 physics.analyzers.REveEventDisplay.filler.addKalSeeds : true
 physics.analyzers.REveEventDisplay.filler.addClusters : true
 physics.analyzers.REveEventDisplay.filler.addHits : true
+physics.analyzers.REveEventDisplay.filler.addTimeClusters : true
 physics.analyzers.REveEventDisplay.filler.addCosmicTrackSeeds : false
 physics.analyzers.REveEventDisplay.filler.addMCTraj : false
 physics.EndPath  : [ @sequence::REveDis.seqBase] 

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -6,11 +6,13 @@ REveEventDisplay : {
     filler : {
      diagLevel : 0
      ComboHitCollection : "makeSH"
+     TimeClusterCollection : "MHDeM"
      CaloClusterCollection : "CaloClusterFast"
      KalSeedCollection : ["KFFDeM"]
      CosmicTrackSeedCollection : "CosmicTrackFinderTimeFit"
      MCTrajectoryCollection : NULL
      addHits : true
+     addTimeClusters : true
      addClusters : true
      addKalSeeds : true
      addCosmicTrackSeeds : false

--- a/fcl/prolog.fcl
+++ b/fcl/prolog.fcl
@@ -13,6 +13,7 @@ REveEventDisplay : {
      MCTrajectoryCollection : NULL
      addHits : true
      addTimeClusters : true
+     addTrkHits : true
      addClusters : true
      addKalSeeds : true
      addCosmicTrackSeeds : false

--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -34,6 +34,7 @@ namespace mu2e{
           fhicl::Sequence<art::InputTag>MCTrajTag{Name("MCTrajectoryCollection"),Comment("MCTrajTag")};
           fhicl::Atom<bool> addHits{Name("addHits"), Comment("set to add the hits"),false};
           fhicl::Atom<bool> addTimeclusters{Name("addTimeClusters"), Comment("set to add the TC hits"),false};
+	  fhicl::Atom<bool> addTrkHits{Name("addTrkHits"), Comment("set to add the Trk hits"),false};
           fhicl::Atom<bool> addClusters{Name("addClusters"), Comment("set to add caloclusters"),false};
           fhicl::Atom<bool> addKalSeeds{Name("addKalSeeds"), Comment("set to add kalseeds"),false};
           fhicl::Atom<bool> addCosmicTrackSeeds{Name("addCosmicTrackSeeds"), Comment("set to add cosmic track seeds"),false};
@@ -53,7 +54,7 @@ namespace mu2e{
         std::vector<art::InputTag> MCTrajTag_;
         art::Event *_event;
         art::Run *_run;
-        bool addHits_,  addTimeClusters_, addClusters_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_, FillAll_;
+        bool addHits_,  addTimeClusters_, addTrkHits_, addClusters_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_, FillAll_;
         void FillRecoCollections(const art::Event& evt, DataCollections &data, RecoDataProductName code);
         void FillMCCollections(const art::Event& evt, DataCollections &data, MCDataProductName code);
         virtual ~CollectionFiller(){};

--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -33,7 +33,7 @@ namespace mu2e{
           fhicl::Atom<art::InputTag>cosmicTrackSeedTag{Name("CosmicTrackSeedCollection"),Comment("cosmicTrackSeedTag")};
           fhicl::Atom<art::InputTag>MCTrajTag{Name("MCTrajectoryCollection"),Comment("MCTrajTag")};
           fhicl::Atom<bool> addHits{Name("addHits"), Comment("set to add the hits"),false};
-          fhicl::Atom<bool> addTimeclusters{Name("addTimeClusters"), Comment("set to add the TC hits"),false};
+          fhicl::Atom<bool> addTimeClusters{Name("addTimeClusters"), Comment("set to add the TC hits"),false};
 	  fhicl::Atom<bool> addTrkHits{Name("addTrkHits"), Comment("set to add the Trk hits"),false};
           fhicl::Atom<bool> addClusters{Name("addClusters"), Comment("set to add caloclusters"),false};
           fhicl::Atom<bool> addKalSeeds{Name("addKalSeeds"), Comment("set to add kalseeds"),false};

--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -31,7 +31,7 @@ namespace mu2e{
           fhicl::Atom<art::InputTag>cluTag{Name("CaloClusterCollection"),Comment("cluTag")};
           fhicl::Sequence<art::InputTag>kalSeedTag{Name("KalSeedCollection"),Comment("kalseedTag")};
           fhicl::Atom<art::InputTag>cosmicTrackSeedTag{Name("CosmicTrackSeedCollection"),Comment("cosmicTrackSeedTag")};
-          fhicl::Sequence<art::InputTag>MCTrajTag{Name("MCTrajectoryCollection"),Comment("MCTrajTag")};
+          fhicl::Atom<art::InputTag>MCTrajTag{Name("MCTrajectoryCollection"),Comment("MCTrajTag")};
           fhicl::Atom<bool> addHits{Name("addHits"), Comment("set to add the hits"),false};
           fhicl::Atom<bool> addTimeclusters{Name("addTimeClusters"), Comment("set to add the TC hits"),false};
 	  fhicl::Atom<bool> addTrkHits{Name("addTrkHits"), Comment("set to add the Trk hits"),false};
@@ -51,7 +51,7 @@ namespace mu2e{
         art::InputTag cluTag_;
         std::vector<art::InputTag> kalSeedTag_;
         art::InputTag cosmicTrackSeedTag_;
-        std::vector<art::InputTag> MCTrajTag_;
+        art::InputTag MCTrajTag_;
         art::Event *_event;
         art::Run *_run;
         bool addHits_,  addTimeClusters_, addTrkHits_, addClusters_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_, FillAll_;

--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -17,7 +17,7 @@
 
 namespace mu2e{
 
-  enum RecoDataProductName {ComboHits, CaloClusters, KalSeeds, CosmicTrackSeeds};
+  enum RecoDataProductName {ComboHits, TimeClusters, CaloClusters, KalSeeds, CosmicTrackSeeds};
   enum MCDataProductName {MCTrajectories};
 	class CollectionFiller
 	{
@@ -27,11 +27,13 @@ namespace mu2e{
           using Comment=fhicl::Comment;
           fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("for info"),0};
           fhicl::Atom<art::InputTag>chTag{Name("ComboHitCollection"),Comment("chTag"), "makePH"};
+	  fhicl::Atom<art::InputTag>tcTag{Name("TimeClusterCollection"),Comment("ttcTag"), "makePH"};
           fhicl::Atom<art::InputTag>cluTag{Name("CaloClusterCollection"),Comment("cluTag")};
           fhicl::Sequence<art::InputTag>kalSeedTag{Name("KalSeedCollection"),Comment("kalseedTag")};
           fhicl::Atom<art::InputTag>cosmicTrackSeedTag{Name("CosmicTrackSeedCollection"),Comment("cosmicTrackSeedTag")};
           fhicl::Sequence<art::InputTag>MCTrajTag{Name("MCTrajectoryCollection"),Comment("MCTrajTag")};
           fhicl::Atom<bool> addHits{Name("addHits"), Comment("set to add the hits"),false};
+          fhicl::Atom<bool> addTimeclusters{Name("addTimeClusters"), Comment("set to add the TC hits"),false};
           fhicl::Atom<bool> addClusters{Name("addClusters"), Comment("set to add caloclusters"),false};
           fhicl::Atom<bool> addKalSeeds{Name("addKalSeeds"), Comment("set to add kalseeds"),false};
           fhicl::Atom<bool> addCosmicTrackSeeds{Name("addCosmicTrackSeeds"), Comment("set to add cosmic track seeds"),false};
@@ -44,13 +46,14 @@ namespace mu2e{
         CollectionFiller& operator=(const CollectionFiller &);
 
         art::InputTag chTag_;
+	art::InputTag tcTag_;
         art::InputTag cluTag_;
         std::vector<art::InputTag> kalSeedTag_;
         art::InputTag cosmicTrackSeedTag_;
         std::vector<art::InputTag> MCTrajTag_;
         art::Event *_event;
         art::Run *_run;
-        bool addHits_,  addClusters_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_, FillAll_;
+        bool addHits_,  addTimeClusters_, addClusters_, addKalSeeds_, addCosmicTrackSeeds_, addMCTraj_, FillAll_;
         void FillRecoCollections(const art::Event& evt, DataCollections &data, RecoDataProductName code);
         void FillMCCollections(const art::Event& evt, DataCollections &data, MCDataProductName code);
         virtual ~CollectionFiller(){};

--- a/inc/DataCollections.hh
+++ b/inc/DataCollections.hh
@@ -3,6 +3,7 @@
 
 #include "Offline/RecoDataProducts/inc/CaloCluster.hh"
 #include "Offline/RecoDataProducts/inc/ComboHit.hh"
+#include "Offline/RecoDataProducts/inc/TimeCluster.hh"
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/CosmicTrackSeed.hh"
 #include "Offline/MCDataProducts/inc/MCTrajectoryPoint.hh"
@@ -33,7 +34,8 @@ namespace mu2e{
       DataCollections& operator=(const DataCollections &);
 
       //DataProducts:
-      const mu2e::ComboHitCollection* chcol = 0;    
+      const mu2e::ComboHitCollection* chcol = 0;   
+      const TimeClusterCollection *tccol = 0;
       const mu2e::CaloClusterCollection* clustercol = 0;
       const mu2e::KalSeedCollection* kalSeedcol = 0;
       const mu2e::CosmicTrackSeedCollection* CosmicTrackSeedcol = 0;

--- a/inc/REveMainWindow.hh
+++ b/inc/REveMainWindow.hh
@@ -57,7 +57,7 @@ namespace mu2e {
       bool addMCTraj = false;
       DrawOptions(){};
       DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool timeclusters, bool trkhits, bool mctraj) 
-      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTimeClusters(timeclusters), addTrkHits(trkhits), addMCTraj(mctraj){};
+      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addHits(combohits), addTimeClusters(timeclusters), addTrkHits(trkhits), addMCTraj(mctraj){};
      };
      
     class REveMainWindow  : public REX::REveElement {

--- a/inc/REveMainWindow.hh
+++ b/inc/REveMainWindow.hh
@@ -53,10 +53,11 @@ namespace mu2e {
       bool addClusters = false; 
       bool addComboHits = false;
       bool addTimeClusters = false;
+      bool addTrkHits = false;
       bool addMCTraj = false;
       DrawOptions(){};
-      DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool timeclusters, bool mctraj) 
-      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTimeClusters(timeclusters), addMCTraj(mctraj){};
+      DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool timeclusters, bool trkhits, bool mctraj) 
+      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTimeClusters(timeclusters), addTrkHits(trkhits), addMCTraj(mctraj){};
      };
      
     class REveMainWindow  : public REX::REveElement {

--- a/inc/REveMainWindow.hh
+++ b/inc/REveMainWindow.hh
@@ -52,9 +52,10 @@ namespace mu2e {
       bool addTracks = false;
       bool addClusters = false; 
       bool addComboHits = false;
+      bool addTimeClusters = false;
       DrawOptions(){};
-      DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits) 
-      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits){};
+      DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool timeclusters) 
+      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTimeClusters(timeclusters){};
      };
      
     class REveMainWindow  : public REX::REveElement {

--- a/inc/REveMainWindow.hh
+++ b/inc/REveMainWindow.hh
@@ -51,7 +51,7 @@ namespace mu2e {
       bool addCosmicTracks = false;
       bool addTracks = false;
       bool addClusters = false; 
-      bool addComboHits = false;
+      bool addHits = false;
       bool addTimeClusters = false;
       bool addTrkHits = false;
       bool addMCTraj = false;

--- a/inc/REveMainWindow.hh
+++ b/inc/REveMainWindow.hh
@@ -53,9 +53,10 @@ namespace mu2e {
       bool addClusters = false; 
       bool addComboHits = false;
       bool addTimeClusters = false;
+      bool addMCTraj = false;
       DrawOptions(){};
-      DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool timeclusters) 
-      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTimeClusters(timeclusters){};
+      DrawOptions(bool crv, bool cosmictracks, bool tracks, bool clusters, bool combohits, bool timeclusters, bool mctraj) 
+      : addCRVInfo(crv), addCosmicTracks(cosmictracks), addTracks(tracks), addClusters(clusters), addComboHits(combohits), addTimeClusters(timeclusters), addMCTraj(mctraj){};
      };
      
     class REveMainWindow  : public REX::REveElement {

--- a/inc/REveMainWindow.hh
+++ b/inc/REveMainWindow.hh
@@ -40,7 +40,7 @@
 #include "art/Framework/Principal/Event.h"
 #include "REve/inc/DataCollections.hh"
 #include "REve/inc/REveMu2eDataInterface.hh"
-
+#include "REve/inc/REveMu2eMCInterface.hh"
 namespace REX = ROOT::Experimental;
  
 namespace mu2e {
@@ -67,6 +67,7 @@ namespace mu2e {
             virtual ~REveMainWindow() {}
             #ifndef __CINT__
             REveMu2eDataInterface *pass_data;
+            REveMu2eMCInterface *pass_mc;
             void makeEveGeoShape(TGeoNode* n, REX::REveTrans& trans, REX::REveElement* holder, int j, bool crys1, bool crys2);
             void showNodesByName(TGeoNode* n, const std::string& str, bool onOff, int _diagLevel, REX::REveTrans& trans,  REX::REveElement* holder, int maxlevel, int level, bool shift, bool crystal, bool crvshift);
             void SolenoidsOnly(TGeoNode* node, REX::REveTrans& trans,  REX::REveElement* holder, int maxlevel, int level, bool addCRV); 

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -11,6 +11,7 @@
 #include "Offline/RecoDataProducts/inc/KalSeed.hh"
 #include "Offline/RecoDataProducts/inc/CosmicTrackSeed.hh"
 #include "Offline/RecoDataProducts/inc/ComboHit.hh"
+#include "Offline/RecoDataProducts/inc/TimeCluster.hh"
 #include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/CalorimeterGeom/inc/CaloGeomUtil.hh"
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -32,7 +32,10 @@ namespace REX = ROOT::Experimental;
 namespace mu2e{
     class REveMu2eDataInterface {
         public:
-         
+          static int const trkhitstyle = 9;
+          static int const trkhitsize=1;
+          static int const mstyle = 4;
+          static int const msize=6;
           explicit REveMu2eDataInterface(){};
           explicit REveMu2eDataInterface(const REveMu2eDataInterface &);
           REveMu2eDataInterface& operator=(const REveMu2eDataInterface &);

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -40,6 +40,7 @@ namespace mu2e{
           #ifndef __CINT__
           void AddComboHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol, REX::REveElement* &scene);
           void AddTimeClusters(REX::REveManager *&eveMng, bool firstloop, const mu2e::TimeClusterCollection *tccol, REX::REveElement* &scene);
+          void AddTrkHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol, std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene);
           void AddCaloClusters(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::CaloClusterCollection *clustercol, REX::REveElement* &scene);
           void AddKalSeedCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene);
           void AddCosmicTrackFit(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::CosmicTrackSeedCollection *cosmiccol, REX::REveElement* &scene);

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -38,6 +38,7 @@ namespace mu2e{
           virtual ~REveMu2eDataInterface() = default;
           #ifndef __CINT__
           void AddComboHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol, REX::REveElement* &scene);
+          void AddTimeClusters(REX::REveManager *&eveMng, bool firstloop, const TimeClusterCollection *tccol, REX::REveElement* &scene);
           void AddCaloClusters(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::CaloClusterCollection *clustercol, REX::REveElement* &scene);
           void AddKalSeedCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene);
           void AddCosmicTrackFit(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::CosmicTrackSeedCollection *cosmiccol, REX::REveElement* &scene);

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -32,8 +32,6 @@ namespace REX = ROOT::Experimental;
 namespace mu2e{
     class REveMu2eDataInterface {
         public:
-          static int const trkhitstyle = 9;
-          static int const trkhitsize=1;
           static int const mstyle = 4;
           static int const msize=6;
           explicit REveMu2eDataInterface(){};

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -39,7 +39,7 @@ namespace mu2e{
           virtual ~REveMu2eDataInterface() = default;
           #ifndef __CINT__
           void AddComboHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol, REX::REveElement* &scene);
-          void AddTimeClusters(REX::REveManager *&eveMng, bool firstloop, const TimeClusterCollection *tccol, REX::REveElement* &scene);
+          void AddTimeClusters(REX::REveManager *&eveMng, bool firstloop, const mu2e::TimeClusterCollection *tccol, REX::REveElement* &scene);
           void AddCaloClusters(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::CaloClusterCollection *clustercol, REX::REveElement* &scene);
           void AddKalSeedCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene);
           void AddCosmicTrackFit(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::CosmicTrackSeedCollection *cosmiccol, REX::REveElement* &scene);

--- a/inc/REveMu2eMCInterface.hh
+++ b/inc/REveMu2eMCInterface.hh
@@ -30,8 +30,7 @@ namespace mu2e{
           REveMu2eMCInterface& operator=(const REveMu2eMCInterface &);
           virtual ~REveMu2eMCInterface() = default;
           #ifndef __CINT__
-          int Contains(std::vector<int> v, int x);
-          void AddMCTrajectoryCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const MCTrajectoryCollection *>> track_tuple, REX::REveElement* &scene, std::vector<int> particleIds);
+          void AddMCTrajectoryCollection(REX::REveManager *&eveMng, bool firstLoop, const MCTrajectoryCollection *trajcol, REX::REveElement* &scene);
           #endif
           ClassDef(REveMu2eMCInterface, 0);
       }; 

--- a/src/CollectionFiller.cc
+++ b/src/CollectionFiller.cc
@@ -67,20 +67,11 @@ namespace mu2e{
     void CollectionFiller::FillMCCollections(const art::Event& evt, DataCollections &data, MCDataProductName CollectionName){
 
         if(FillAll_ or (CollectionName==MCTrajectories)){
-          
-            for(const auto &tag : kalSeedTag_){
-                auto chH = evt.getValidHandle<mu2e::MCTrajectoryCollection>(tag);
+               auto chH = evt.getValidHandle<mu2e::MCTrajectoryCollection>(tag);
                 data.mctrajcol = chH.product();
-                data.mctrack_list.push_back(data.mctrajcol);
-
-                std::string name = TurnNameToString(tag);
+                
                 std::cout<<"Plotting MCTrajectory Instance: "<<name<<std::endl;
-                data.mctrack_labels.push_back(name);
-
-            }
-            data.mctrack_tuple = std::make_tuple(data.mctrack_labels,data.mctrack_list);
-            std::cout<<"size "<<data.track_list.size()<<std::endl;
-        }
+                }
         
     }
 

--- a/src/CollectionFiller.cc
+++ b/src/CollectionFiller.cc
@@ -76,12 +76,9 @@ namespace mu2e{
                auto chH = evt.getValidHandle<mu2e::MCTrajectoryCollection>(MCTrajTag_);
                 data.mctrajcol = chH.product();
                 
-                std::cout<<"Plotting MCTrajectory Instance: "<<name<<std::endl;
+		// std::cout<<"Plotting MCTrajectory Instance: "<<name<<std::endl;
                 }
         
     }
 
 }
-
-
-

--- a/src/CollectionFiller.cc
+++ b/src/CollectionFiller.cc
@@ -73,7 +73,7 @@ namespace mu2e{
     void CollectionFiller::FillMCCollections(const art::Event& evt, DataCollections &data, MCDataProductName CollectionName){
 
         if(FillAll_ or (CollectionName==MCTrajectories)){
-               auto chH = evt.getValidHandle<mu2e::MCTrajectoryCollection>(tag);
+               auto chH = evt.getValidHandle<mu2e::MCTrajectoryCollection>(MCTrajTag_);
                 data.mctrajcol = chH.product();
                 
                 std::cout<<"Plotting MCTrajectory Instance: "<<name<<std::endl;

--- a/src/CollectionFiller.cc
+++ b/src/CollectionFiller.cc
@@ -15,6 +15,8 @@ namespace mu2e{
         cosmicTrackSeedTag_(conf.cosmicTrackSeedTag()),
         MCTrajTag_(conf.MCTrajTag()),
         addHits_(conf.addHits()),
+        addTimeClusters_(conf.addTimeClusters()),
+        addTrkHits_(conf.addTrkHits()),
         addClusters_(conf.addClusters()),
         addKalSeeds_(conf.addKalSeeds()),
         addCosmicTrackSeeds_(conf.addCosmicTrackSeeds()),
@@ -38,6 +40,10 @@ namespace mu2e{
         if(FillAll_  or (CollectionName == TimeClusters)){ 
            auto chH = evt.getValidHandle<mu2e::TimeClusterCollection>(tcTag_);
            data.tccol = chH.product();
+        }
+        if(FillAll_ or (addTrkHits_ and CollectionName == ComboHits)){ 
+           auto chH = evt.getValidHandle<mu2e::ComboHitCollection>(chTag_);
+           data.chcol = chH.product();
         }
         if(FillAll_  or (CollectionName == CaloClusters)){
             auto chH = evt.getValidHandle<mu2e::CaloClusterCollection>(cluTag_);

--- a/src/CollectionFiller.cc
+++ b/src/CollectionFiller.cc
@@ -9,6 +9,7 @@ namespace mu2e{
 
     CollectionFiller::CollectionFiller(const Config& conf) :
         chTag_(conf.chTag()),
+        tcTag_(conf.tcTag()),
         cluTag_(conf.cluTag()),
         kalSeedTag_(conf.kalSeedTag()),
         cosmicTrackSeedTag_(conf.cosmicTrackSeedTag()),
@@ -33,6 +34,10 @@ namespace mu2e{
         if(FillAll_  or (CollectionName == ComboHits)){ 
             auto chH = evt.getValidHandle<mu2e::ComboHitCollection>(chTag_);
             data.chcol = chH.product();
+        }
+        if(FillAll_  or (CollectionName == TimeClusters)){ 
+           auto chH = evt.getValidHandle<mu2e::TimeClusterCollection>(tcTag_);
+           data.tccol = chH.product();
         }
         if(FillAll_  or (CollectionName == CaloClusters)){
             auto chH = evt.getValidHandle<mu2e::CaloClusterCollection>(cluTag_);

--- a/src/REveEventDisplay_module.cc
+++ b/src/REveEventDisplay_module.cc
@@ -183,6 +183,7 @@ namespace mu2e
     std::cout<<"*********** REve Mu2e **************"
     <<" User Options: "
     <<" addHits : "<<filler_.addHits_
+    <<" addTimeClusters : "<<filler_.addTimeClusters_
     <<" addClusters : "<<filler_.addClusters_
     <<" addTracks : "<<filler_.addKalSeeds_
     <<" addCosmicTrackSeeds : "<<filler_.addCosmicTrackSeeds_<<std::endl;
@@ -202,6 +203,7 @@ namespace mu2e
       std::cout<<"[REveEventDisplay : analyze()] -- Fill collections "<<std::endl;
       if(filler_.addClusters_)  filler_.FillRecoCollections(event, data, CaloClusters);
       if(filler_.addHits_)  filler_.FillRecoCollections(event, data, ComboHits);
+      if(_filler.addTimeClusters_)_filler.FillRecoCollections(event, data, TimeClusters);
       if(filler_.addKalSeeds_)  filler_.FillRecoCollections(event, data, KalSeeds);
       if(filler_.addCosmicTrackSeeds_)  filler_.FillRecoCollections(event, data, CosmicTrackSeeds);
       if(filler_.addMCTraj_)  filler_.FillMCCollections(event, data, MCTrajectories);
@@ -270,7 +272,7 @@ namespace mu2e
       REX::REveElement* scene = eveMng_->GetEventScene();
 
       std::cout<<"[REveEventDisplay : process_single_event] -- calls to data interface "<<std::endl;
-      DrawOptions drawOpts(false, filler_.addCosmicTrackSeeds_, filler_.addKalSeeds_, filler_.addClusters_, filler_.addHits_);
+      DrawOptions drawOpts(false, filler_.addCosmicTrackSeeds_, filler_.addKalSeeds_, filler_.addClusters_, filler_.addHits_, filler.addTimeClusters_);
       frame_->showEvents(eveMng_, scene, firstLoop_, data, drawOpts);
       
       std::cout<<"[REveEventDisplay : process_single_event] -- cluster added to scene "<<std::endl;

--- a/src/REveEventDisplay_module.cc
+++ b/src/REveEventDisplay_module.cc
@@ -204,6 +204,7 @@ namespace mu2e
       if(filler_.addHits_)  filler_.FillRecoCollections(event, data, ComboHits);
       if(filler_.addKalSeeds_)  filler_.FillRecoCollections(event, data, KalSeeds);
       if(filler_.addCosmicTrackSeeds_)  filler_.FillRecoCollections(event, data, CosmicTrackSeeds);
+      if(filler_.addMCTraj_)  filler_.FillMCCollections(event, data, MCTrajectories);
      
       //if (displayedEventID_ != test::invalid_event)
       //{

--- a/src/REveEventDisplay_module.cc
+++ b/src/REveEventDisplay_module.cc
@@ -204,6 +204,7 @@ namespace mu2e
       if(filler_.addClusters_)  filler_.FillRecoCollections(event, data, CaloClusters);
       if(filler_.addHits_)  filler_.FillRecoCollections(event, data, ComboHits);
       if(filler_.addTimeClusters_) filler_.FillRecoCollections(event, data, TimeClusters);
+      if(filler_.addTrkHits_) filler_.FillRecoCollections(event, data, ComboHits);
       if(filler_.addKalSeeds_)  filler_.FillRecoCollections(event, data, KalSeeds);
       if(filler_.addCosmicTrackSeeds_)  filler_.FillRecoCollections(event, data, CosmicTrackSeeds);
       if(filler_.addMCTraj_)  filler_.FillMCCollections(event, data, MCTrajectories);
@@ -272,7 +273,7 @@ namespace mu2e
       REX::REveElement* scene = eveMng_->GetEventScene();
 
       std::cout<<"[REveEventDisplay : process_single_event] -- calls to data interface "<<std::endl;
-      DrawOptions drawOpts(false, filler_.addCosmicTrackSeeds_, filler_.addKalSeeds_, filler_.addClusters_, filler_.addHits_, filler_.addTimeClusters_, filler_.addMCTraj_);
+      DrawOptions drawOpts(false, filler_.addCosmicTrackSeeds_, filler_.addKalSeeds_, filler_.addClusters_, filler_.addHits_, filler_.addTimeClusters_, filler_.addTrkHits_, filler_.addMCTraj_);
       frame_->showEvents(eveMng_, scene, firstLoop_, data, drawOpts);
       
       std::cout<<"[REveEventDisplay : process_single_event] -- cluster added to scene "<<std::endl;

--- a/src/REveEventDisplay_module.cc
+++ b/src/REveEventDisplay_module.cc
@@ -203,7 +203,7 @@ namespace mu2e
       std::cout<<"[REveEventDisplay : analyze()] -- Fill collections "<<std::endl;
       if(filler_.addClusters_)  filler_.FillRecoCollections(event, data, CaloClusters);
       if(filler_.addHits_)  filler_.FillRecoCollections(event, data, ComboHits);
-      if(_filler.addTimeClusters_)_filler.FillRecoCollections(event, data, TimeClusters);
+      if(filler_.addTimeClusters_) filler_.FillRecoCollections(event, data, TimeClusters);
       if(filler_.addKalSeeds_)  filler_.FillRecoCollections(event, data, KalSeeds);
       if(filler_.addCosmicTrackSeeds_)  filler_.FillRecoCollections(event, data, CosmicTrackSeeds);
       if(filler_.addMCTraj_)  filler_.FillMCCollections(event, data, MCTrajectories);
@@ -272,7 +272,7 @@ namespace mu2e
       REX::REveElement* scene = eveMng_->GetEventScene();
 
       std::cout<<"[REveEventDisplay : process_single_event] -- calls to data interface "<<std::endl;
-      DrawOptions drawOpts(false, filler_.addCosmicTrackSeeds_, filler_.addKalSeeds_, filler_.addClusters_, filler_.addHits_, filler.addTimeClusters_);
+      DrawOptions drawOpts(false, filler_.addCosmicTrackSeeds_, filler_.addKalSeeds_, filler_.addClusters_, filler_.addHits_, filler_.addTimeClusters_, filler_.addMCTraj_);
       frame_->showEvents(eveMng_, scene, firstLoop_, data, drawOpts);
       
       std::cout<<"[REveEventDisplay : process_single_event] -- cluster added to scene "<<std::endl;

--- a/src/REveMainWindow.cc
+++ b/src/REveMainWindow.cc
@@ -181,10 +181,12 @@ void REveMainWindow::showNodesByName(TGeoNode* n, const std::string& str, bool o
     if(drawOpts.addClusters and data.clustercol->size() !=0) pass_data->AddCaloClusters(eveMng, firstLoop, data.clustercol, eventScene);
     if(drawOpts.addComboHits and data.chcol->size() !=0) pass_data->AddComboHits(eveMng, firstLoop, data.chcol, eventScene);
     if(drawOpts.addTimeClusters and data.tccol->size() !=0) pass_data->AddTimeClusters(eveMng, firstLoop, data.tccol, eventScene);
+    if(drawOpts.addTrkHits and data.chcol->size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);
     std::vector<const KalSeedCollection*> track_list = std::get<1>(data.track_tuple);
+    if(drawOpts.addTrkHits and data.chcol->size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);
     if(drawOpts.addTracks and track_list.size() !=0) pass_data->AddKalSeedCollection(eveMng, firstLoop, data.track_tuple, eventScene);
     if(drawOpts.addCosmicTracks) pass_data->AddCosmicTrackFit(eveMng, firstLoop, data.CosmicTrackSeedcol, eventScene);
-    if(DrawOpts.addMCTraj) pass_mc->AddMCTrajectoryCollection(eveMng,firstloop, data.mctrajcol, eventScene, particles);
+    if(drawOpts.addMCTraj) pass_mc->AddMCTrajectoryCollection(eveMng, firstLoop, data.mctrajcol, eventScene);
 	 projectEvents(eveMng);
  }
 

--- a/src/REveMainWindow.cc
+++ b/src/REveMainWindow.cc
@@ -184,7 +184,8 @@ void REveMainWindow::showNodesByName(TGeoNode* n, const std::string& str, bool o
     std::vector<const KalSeedCollection*> track_list = std::get<1>(data.track_tuple);
     if(drawOpts.addTracks and track_list.size() !=0) pass_data->AddKalSeedCollection(eveMng, firstLoop, data.track_tuple, eventScene);
     if(drawOpts.addCosmicTracks) pass_data->AddCosmicTrackFit(eveMng, firstLoop, data.CosmicTrackSeedcol, eventScene);
-    projectEvents(eveMng);
+    if(DrawOpts.addMCTraj) pass_mc->AddMCTrajectoryCollection(eveMng,firstloop, data.mctrajcol, eventScene, particles);
+	 projectEvents(eveMng);
  }
 
  void REveMainWindow::makeGeometryScene(REX::REveManager *eveMng, bool addCRV)

--- a/src/REveMainWindow.cc
+++ b/src/REveMainWindow.cc
@@ -186,7 +186,7 @@ void REveMainWindow::showNodesByName(TGeoNode* n, const std::string& str, bool o
     if(drawOpts.addTrkHits and data.chcol->size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);
     if(drawOpts.addTracks and track_list.size() !=0) pass_data->AddKalSeedCollection(eveMng, firstLoop, data.track_tuple, eventScene);
     if(drawOpts.addCosmicTracks) pass_data->AddCosmicTrackFit(eveMng, firstLoop, data.CosmicTrackSeedcol, eventScene);
-    if(drawOpts.addMCTraj) pass_mc->AddMCTrajectoryCollection(eveMng, firstLoop, data.mctrajcol, eventScene);
+    if(drawOpts.addMCTraj and data.mctrajcol->size() !=0) pass_mc->AddMCTrajectoryCollection(eveMng, firstLoop, data.mctrajcol, eventScene);
 	 projectEvents(eveMng);
  }
 

--- a/src/REveMainWindow.cc
+++ b/src/REveMainWindow.cc
@@ -181,9 +181,8 @@ void REveMainWindow::showNodesByName(TGeoNode* n, const std::string& str, bool o
     if(drawOpts.addClusters and data.clustercol->size() !=0) pass_data->AddCaloClusters(eveMng, firstLoop, data.clustercol, eventScene);
     if(drawOpts.addComboHits and data.chcol->size() !=0) pass_data->AddComboHits(eveMng, firstLoop, data.chcol, eventScene);
     if(drawOpts.addTimeClusters and data.tccol->size() !=0) pass_data->AddTimeClusters(eveMng, firstLoop, data.tccol, eventScene);
-    if(drawOpts.addTrkHits and data.chcol->size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);
     std::vector<const KalSeedCollection*> track_list = std::get<1>(data.track_tuple);
-    if(drawOpts.addTrkHits and data.chcol->size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);
+    if(drawOpts.addTrkHits and data.chcol->size() !=0 and track_list.size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);
     if(drawOpts.addTracks and track_list.size() !=0) pass_data->AddKalSeedCollection(eveMng, firstLoop, data.track_tuple, eventScene);
     if(drawOpts.addCosmicTracks) pass_data->AddCosmicTrackFit(eveMng, firstLoop, data.CosmicTrackSeedcol, eventScene);
     if(drawOpts.addMCTraj and data.mctrajcol->size() !=0) pass_mc->AddMCTrajectoryCollection(eveMng, firstLoop, data.mctrajcol, eventScene);

--- a/src/REveMainWindow.cc
+++ b/src/REveMainWindow.cc
@@ -180,6 +180,7 @@ void REveMainWindow::showNodesByName(TGeoNode* n, const std::string& str, bool o
  void REveMainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventScene, bool firstLoop, DataCollections &data, DrawOptions drawOpts){
     if(drawOpts.addClusters and data.clustercol->size() !=0) pass_data->AddCaloClusters(eveMng, firstLoop, data.clustercol, eventScene);
     if(drawOpts.addComboHits and data.chcol->size() !=0) pass_data->AddComboHits(eveMng, firstLoop, data.chcol, eventScene);
+    if(drawOpts.addTimeClusters and data.tccol->size() !=0) pass_data->AddTimeClusters(eveMng, firstLoop, data.tccol, eventScene);
     std::vector<const KalSeedCollection*> track_list = std::get<1>(data.track_tuple);
     if(drawOpts.addTracks and track_list.size() !=0) pass_data->AddKalSeedCollection(eveMng, firstLoop, data.track_tuple, eventScene);
     if(drawOpts.addCosmicTracks) pass_data->AddCosmicTrackFit(eveMng, firstLoop, data.CosmicTrackSeedcol, eventScene);

--- a/src/REveMainWindow.cc
+++ b/src/REveMainWindow.cc
@@ -179,7 +179,7 @@ void REveMainWindow::showNodesByName(TGeoNode* n, const std::string& str, bool o
 
  void REveMainWindow::showEvents(REX::REveManager *eveMng, REX::REveElement* &eventScene, bool firstLoop, DataCollections &data, DrawOptions drawOpts){
     if(drawOpts.addClusters and data.clustercol->size() !=0) pass_data->AddCaloClusters(eveMng, firstLoop, data.clustercol, eventScene);
-    if(drawOpts.addComboHits and data.chcol->size() !=0) pass_data->AddComboHits(eveMng, firstLoop, data.chcol, eventScene);
+    if(drawOpts.addHits and data.chcol->size() !=0) pass_data->AddComboHits(eveMng, firstLoop, data.chcol, eventScene);
     if(drawOpts.addTimeClusters and data.tccol->size() !=0) pass_data->AddTimeClusters(eveMng, firstLoop, data.tccol, eventScene);
     std::vector<const KalSeedCollection*> track_list = std::get<1>(data.track_tuple);
     if(drawOpts.addTrkHits and data.chcol->size() !=0 and track_list.size() !=0) pass_data->AddTrkHits(eveMng, firstLoop, data.chcol, data.track_tuple, eventScene);

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -138,7 +138,7 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
 	    // CLHEP::Hep3Vector HitPos = det->toMu2e(HitPosition);
             auto notusedtrkhit = new REX::REvePointSet("NotTrkHits", "nottrkhit",0); 
             notusedtrkhit ->SetMarkerStyle(REveMu2eDataInterface::mstyle);
-            notusedtrkhit ->SetMarkerSize()REveMu2eDataInterface::msize;
+            notusedtrkhit ->SetMarkerSize(REveMu2eDataInterface::msize);
             notusedtrkhit ->SetNextPoint(HitPos.x()/10,HitPos.y()/10 + 100,HitPos.z()/10);
             notusedtrkhit ->SetMarkerColor(kRed-4);
 	    if(notusedtrkhit->GetSize() !=0 ) scene->AddElement(notusedtrkhit); 

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -88,7 +88,7 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
   }
 	
 /*------------Function to color code the Tracker hits in 3D and 2D displays:-------------*/
-  void TEveMu2eDataInterface::AddTrkHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol,
+  void REveMu2eDataInterface::AddTrkHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol,
 					 std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene){
     std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
     std::cout<<"[REveMu2eDataInterface] AddTrkHits  "<<std::endl;

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -32,12 +32,12 @@ void REveMu2eDataInterface::AddCaloClusters(REX::REveManager *&eveMng, bool firs
             if(cluster.diskID() == 1) ps2->SetNextPoint(COG.x()/10, COG.y()/10 +100, abs(pointInMu2e.z())/10); 
 
             ps1->SetMarkerColor(kRed);
-            ps1->SetMarkerStyle(4);
-            ps1->SetMarkerSize(4);
+            ps1->SetMarkerStyle(REveMu2eDataInterface::mstyle);
+            ps1->SetMarkerSize(REveMu2eDataInterface::mstyle);
 
             ps2->SetMarkerColor(kRed);
-            ps2->SetMarkerStyle(4);
-            ps2->SetMarkerSize(4);
+            ps2->SetMarkerStyle(REveMu2eDataInterface::mstyle);
+            ps2->SetMarkerSize(REveMu2eDataInterface::mstyle);
         
             if(ps1->GetSize() !=0 ) scene->AddElement(ps1); 
             if(ps2->GetSize() !=0 ) scene->AddElement(ps2); 
@@ -60,8 +60,8 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
         }
   
         ps1->SetMarkerColor(kBlue);
-        ps1->SetMarkerStyle(4);
-        ps1->SetMarkerSize(6);
+        ps1->SetMarkerStyle(REveMu2eDataInterface::mstyle);
+        ps1->SetMarkerSize(REveMu2eDataInterface::msize);
         if(ps1->GetSize() !=0 ) scene->AddElement(ps1); 
     }
 }
@@ -80,8 +80,8 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
           ps1->SetNextPoint(HitPos.x()/10, HitPos.y()/10 +100, HitPos.z()/10); 
         }
         ps1->SetMarkerColor(kGreen);
-        ps1->SetMarkerStyle(4);
-        ps1->SetMarkerSize(6);
+        ps1->SetMarkerStyle(REveMu2eDataInterface::mstyle);
+        ps1->SetMarkerSize(REveMu2eDataInterface::msize);
         if(ps1->GetSize() !=0 ) scene->AddElement(ps1); 
       }
   }
@@ -122,8 +122,8 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
               CLHEP::Hep3Vector HitPos(hit.pos().x(), hit.pos().y(), hit.pos().z());
 	      // CLHEP::Hep3Vector HitPos = det->toMu2e(HitPosition);
               auto trkhit = new REX::REvePointSet("TrkHits", "trkhit",0); 
-              trkhit ->SetMarkerStyle(9);
-	      trkhit ->SetMarkerSize(1);
+              trkhit ->SetMarkerStyle(REveMu2eDataInterface::mstyle);
+	      trkhit ->SetMarkerSize(REveMu2eDataInterface::msize);
               trkhit ->SetMarkerColor(kGreen-4);
               trkhit ->SetNextPoint(HitPos.x()/10,HitPos.y()/10 + 100,HitPos.z()/10);
               if(trkhit->GetSize() !=0 ) scene->AddElement(trkhit); 
@@ -137,8 +137,8 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
             CLHEP::Hep3Vector HitPos(chhit.pos().x(), chhit.pos().y(), chhit.pos().z());
 	    // CLHEP::Hep3Vector HitPos = det->toMu2e(HitPosition);
             auto notusedtrkhit = new REX::REvePointSet("NotTrkHits", "nottrkhit",0); 
-            notusedtrkhit ->SetMarkerStyle(9);
-            notusedtrkhit ->SetMarkerSize(1);
+            notusedtrkhit ->SetMarkerStyle(REveMu2eDataInterface::mstyle);
+            notusedtrkhit ->SetMarkerSize()REveMu2eDataInterface::msize;
             notusedtrkhit ->SetNextPoint(HitPos.x()/10,HitPos.y()/10 + 100,HitPos.z()/10);
             notusedtrkhit ->SetMarkerColor(kRed-4);
 	    if(notusedtrkhit->GetSize() !=0 ) scene->AddElement(notusedtrkhit); 

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -66,6 +66,28 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
     }
 }
 
+/*------------Function to add TimeCluster Collection in 3D and 2D displays:-------------*/
+  void REveMu2eDataInterface::AddTimeClusters(REX::REveManager *&eveMng, bool firstloop, const mu2e::TimeClusterCollection *tccol, REX::REveElement* &scene){
+     std::cout<<"[REveMu2eDataInterface] AddTimeClusters "<<std::endl;
+     if(tccol!=0){
+         
+          auto ps1 = new REX::REvePointSet("TimeClusters", "",0); // TODO - add in descriptive label
+        if(!firstLoop_){
+            scene->DestroyElements();;
+        }
+      for(size_t i=0; i<tccol->size();i++){
+        mu2e::TimeCluster const  &tclust= (*tccol)[i];
+        CLHEP::Hep3Vector HitPos(tclust._pos.x(), tclust._pos.y(), tclust._pos.z());
+        ps1->SetNextPoint(HitPos.x()/10, HitPos.y()/10 +100, HitPos.z()/10); 
+      }
+      ps1->SetMarkerColor(kGreen);
+        ps1->SetMarkerStyle(4);
+        ps1->SetMarkerSize(6);
+        if(ps1->GetSize() !=0 ) scene->AddElement(ps1); 
+    }
+  }
+	
+
 void REveMu2eDataInterface::AddKalSeedCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene){
     std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
     std::vector<std::string> names = std::get<0>(track_tuple);

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -68,81 +68,83 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
 
 /*------------Function to add TimeCluster Collection in 3D and 2D displays:-------------*/
   void REveMu2eDataInterface::AddTimeClusters(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::TimeClusterCollection *tccol, REX::REveElement* &scene){
-     std::cout<<"[REveMu2eDataInterface] AddTimeClusters "<<std::endl;
-     if(tccol!=0){
-         
-          auto ps1 = new REX::REvePointSet("TimeClusters", "",0); // TODO - add in descriptive label
+      std::cout<<"[REveMu2eDataInterface] AddTimeClusters "<<std::endl;
+      if(tccol!=0){
+        auto ps1 = new REX::REvePointSet("TimeClusters", "TimeCluster", 0); // TODO - add in descriptive label
         if(!firstLoop_){
-            scene->DestroyElements();;
+          scene->DestroyElements();;
         }
-      for(size_t i=0; i<tccol->size();i++){
-        mu2e::TimeCluster const  &tclust= (*tccol)[i];
-        CLHEP::Hep3Vector HitPos(tclust._pos.x(), tclust._pos.y(), tclust._pos.z());
-        ps1->SetNextPoint(HitPos.x()/10, HitPos.y()/10 +100, HitPos.z()/10); 
-      }
-      ps1->SetMarkerColor(kGreen);
+        for(size_t i=0; i<tccol->size();i++){
+          mu2e::TimeCluster const  &tclust= (*tccol)[i];
+          CLHEP::Hep3Vector HitPos(tclust._pos.x(), tclust._pos.y(), tclust._pos.z());
+          ps1->SetNextPoint(HitPos.x()/10, HitPos.y()/10 +100, HitPos.z()/10); 
+        }
+        ps1->SetMarkerColor(kGreen);
         ps1->SetMarkerStyle(4);
         ps1->SetMarkerSize(6);
         if(ps1->GetSize() !=0 ) scene->AddElement(ps1); 
-    }
+      }
   }
 	
 /*------------Function to color code the Tracker hits in 3D and 2D displays:-------------*/
   void REveMu2eDataInterface::AddTrkHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol,
 					 std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene){
-    std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
-    std::cout<<"[REveMu2eDataInterface] AddTrkHits  "<<std::endl;
-    StrawId trksid[70];
-    unsigned int trkhitsize=0;
-    //Save the hit straw IDs of the KalSeed hits  
-    for(unsigned int j=0; j< track_list.size(); j++){
-      const KalSeedCollection* seedcol = track_list[j];
-      if(seedcol!=0){
-        for(unsigned int k = 0; k < seedcol->size(); k++){
-          KalSeed kseed = (*seedcol)[k];
-          const std::vector<mu2e::TrkStrawHitSeed> &hits = kseed.hits();
-          trkhitsize = hits.size();
-          for(unsigned int i=0; i <trkhitsize; i++){
-            const mu2e::TrkStrawHitSeed &hit = hits.at(i);
-            trksid[i] = hit._sid; 
+      std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
+      std::cout<<"[REveMu2eDataInterface] AddTrkHits  "<<std::endl;
+      GeomHandle<DetectorSystem> det;
+      StrawId trksid[70];
+      unsigned int trkhitsize=0;
+      //Save the hit straw IDs of the KalSeed hits  
+      for(unsigned int j=0; j< track_list.size(); j++){
+        const KalSeedCollection* seedcol = track_list[j];
+        if(seedcol!=0){
+          for(unsigned int k = 0; k < seedcol->size(); k++){
+            KalSeed kseed = (*seedcol)[k];
+            const std::vector<mu2e::TrkStrawHitSeed> &hits = kseed.hits();
+            trkhitsize = hits.size();
+            for(unsigned int i=0; i <trkhitsize; i++){
+              const mu2e::TrkStrawHitSeed &hit = hits.at(i);
+              trksid[i] = hit._sid; 
+            }
           }
         }
-      }
-    }        
-    StrawId usedtrksid[trkhitsize];
-    unsigned int usedid[trkhitsize];
-    //Compare the straw IDs of the Kal seed hits with the hits in the ComboHit Collection
-    if(chcol!=0){
-      for(unsigned int i=0; i<chcol->size();i++){
-        ComboHit hit = (*chcol)[i];
-        for(unsigned int q=0; q<trkhitsize; q++){
-          if(hit._sid == trksid[q]){
-            usedid[q]=q;
-            usedtrksid[q]=hit._sid;//Save the Straw ID if the KalSeed and Combo hit ID matches
-            CLHEP::Hep3Vector HitPos(hit.pos().x(), hit.pos().y(), hit.pos().z());
-	    auto trkhit = new REX::REvePointSet("TrkHits", "",0); 
-            trkhit ->SetMarkerStyle(9);
-	    trkhit ->SetMarkerSize(1);
-            trkhit ->SetMarkerColor(kGreen-4);
-            trkhit ->SetNextPoint(HitPos.x(),HitPos.y(),HitPos.z());
-             if(trkhit->GetSize() !=0 ) scene->AddElement(trkhit); 
+      }        
+      StrawId usedtrksid[trkhitsize];
+      unsigned int usedid[trkhitsize];
+      //Compare the straw IDs of the Kal seed hits with the hits in the ComboHit Collection
+      if(chcol!=0){
+        for(unsigned int i=0; i<chcol->size();i++){
+          ComboHit hit = (*chcol)[i];
+          for(unsigned int q=0; q<trkhitsize; q++){
+            if(hit._sid == trksid[q]){
+              usedid[q]=q;
+              usedtrksid[q]=hit._sid;//Save the Straw ID if the KalSeed and Combo hit ID matches
+              CLHEP::Hep3Vector HitPos(hit.pos().x(), hit.pos().y(), hit.pos().z());
+	      // CLHEP::Hep3Vector HitPos = det->toMu2e(HitPosition);
+              auto trkhit = new REX::REvePointSet("TrkHits", "trkhit",0); 
+              trkhit ->SetMarkerStyle(9);
+	      trkhit ->SetMarkerSize(1);
+              trkhit ->SetMarkerColor(kGreen-4);
+              trkhit ->SetNextPoint(HitPos.x()/10,HitPos.y()/10 + 100,HitPos.z()/10);
+              if(trkhit->GetSize() !=0 ) scene->AddElement(trkhit); 
+	    }
+          }
+        }
+        //Hits which are not in the ComboHit Collection of the helix    
+        for(unsigned int i = 0;i < trkhitsize;i++){
+          if(i != usedid[i] && i<chcol->size()){
+            ComboHit chhit = (*chcol)[i];
+            CLHEP::Hep3Vector HitPos(chhit.pos().x(), chhit.pos().y(), chhit.pos().z());
+	    // CLHEP::Hep3Vector HitPos = det->toMu2e(HitPosition);
+            auto notusedtrkhit = new REX::REvePointSet("NotTrkHits", "nottrkhit",0); 
+            notusedtrkhit ->SetMarkerStyle(9);
+            notusedtrkhit ->SetMarkerSize(1);
+            notusedtrkhit ->SetNextPoint(HitPos.x()/10,HitPos.y()/10 + 100,HitPos.z()/10);
+            notusedtrkhit ->SetMarkerColor(kRed-4);
+	    if(notusedtrkhit->GetSize() !=0 ) scene->AddElement(notusedtrkhit); 
 	  }
         }
       }
-      //Hits which are not in the ComboHit Collection of the helix    
-      for(unsigned int i = 0;i < trkhitsize;i++){
-        if(i != usedid[i] && i<chcol->size()){
-          ComboHit chhit = (*chcol)[i];
-          CLHEP::Hep3Vector HitPos(chhit.pos().x(), chhit.pos().y(), chhit.pos().z());
-         auto notusedtrkhit = new REX::REvePointSet("NotTrkHits", "",0); 
-          notusedtrkhit ->SetMarkerStyle(9);
-          notusedtrkhit ->SetMarkerSize(1);
-          notusedtrkhit ->SetNextPoint(HitPos.x(),HitPos.y(),HitPos.z());
-          notusedtrkhit ->SetMarkerColor(kRed-4);
-		if(notusedtrkhit->GetSize() !=0 ) scene->AddElement(trkhit); 
-	}
-      }
-    }
   }
 
 void REveMu2eDataInterface::AddKalSeedCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene){

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -67,7 +67,7 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
 }
 
 /*------------Function to add TimeCluster Collection in 3D and 2D displays:-------------*/
-  void REveMu2eDataInterface::AddTimeClusters(REX::REveManager *&eveMng, bool firstloop, const mu2e::TimeClusterCollection *tccol, REX::REveElement* &scene){
+  void REveMu2eDataInterface::AddTimeClusters(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::TimeClusterCollection *tccol, REX::REveElement* &scene){
      std::cout<<"[REveMu2eDataInterface] AddTimeClusters "<<std::endl;
      if(tccol!=0){
          

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -87,6 +87,63 @@ void REveMu2eDataInterface::AddComboHits(REX::REveManager *&eveMng, bool firstLo
     }
   }
 	
+/*------------Function to color code the Tracker hits in 3D and 2D displays:-------------*/
+  void TEveMu2eDataInterface::AddTrkHits(REX::REveManager *&eveMng, bool firstLoop_, const mu2e::ComboHitCollection *chcol,
+					 std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene){
+    std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);
+    std::cout<<"[REveMu2eDataInterface] AddTrkHits  "<<std::endl;
+    StrawId trksid[70];
+    unsigned int trkhitsize=0;
+    //Save the hit straw IDs of the KalSeed hits  
+    for(unsigned int j=0; j< track_list.size(); j++){
+      const KalSeedCollection* seedcol = track_list[j];
+      if(seedcol!=0){
+        for(unsigned int k = 0; k < seedcol->size(); k++){
+          KalSeed kseed = (*seedcol)[k];
+          const std::vector<mu2e::TrkStrawHitSeed> &hits = kseed.hits();
+          trkhitsize = hits.size();
+          for(unsigned int i=0; i <trkhitsize; i++){
+            const mu2e::TrkStrawHitSeed &hit = hits.at(i);
+            trksid[i] = hit._sid; 
+          }
+        }
+      }
+    }        
+    StrawId usedtrksid[trkhitsize];
+    unsigned int usedid[trkhitsize];
+    //Compare the straw IDs of the Kal seed hits with the hits in the ComboHit Collection
+    if(chcol!=0){
+      for(unsigned int i=0; i<chcol->size();i++){
+        ComboHit hit = (*chcol)[i];
+        for(unsigned int q=0; q<trkhitsize; q++){
+          if(hit._sid == trksid[q]){
+            usedid[q]=q;
+            usedtrksid[q]=hit._sid;//Save the Straw ID if the KalSeed and Combo hit ID matches
+            CLHEP::Hep3Vector HitPos(hit.pos().x(), hit.pos().y(), hit.pos().z());
+	    auto trkhit = new REX::REvePointSet("TrkHits", "",0); 
+            trkhit ->SetMarkerStyle(9);
+	    trkhit ->SetMarkerSize(1);
+            trkhit ->SetMarkerColor(kGreen-4);
+            trkhit ->SetNextPoint(HitPos.x(),HitPos.y(),HitPos.z());
+             if(trkhit->GetSize() !=0 ) scene->AddElement(trkhit); 
+	  }
+        }
+      }
+      //Hits which are not in the ComboHit Collection of the helix    
+      for(unsigned int i = 0;i < trkhitsize;i++){
+        if(i != usedid[i] && i<chcol->size()){
+          ComboHit chhit = (*chcol)[i];
+          CLHEP::Hep3Vector HitPos(chhit.pos().x(), chhit.pos().y(), chhit.pos().z());
+         auto notusedtrkhit = new REX::REvePointSet("NotTrkHits", "",0); 
+          notusedtrkhit ->SetMarkerStyle(9);
+          notusedtrkhit ->SetMarkerSize(1);
+          notusedtrkhit ->SetNextPoint(HitPos.x(),HitPos.y(),HitPos.z());
+          notusedtrkhit ->SetMarkerColor(kRed-4);
+		if(notusedtrkhit->GetSize() !=0 ) scene->AddElement(trkhit); 
+	}
+      }
+    }
+  }
 
 void REveMu2eDataInterface::AddKalSeedCollection(REX::REveManager *&eveMng,bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const KalSeedCollection*>> track_tuple, REX::REveElement* &scene){
     std::vector<const KalSeedCollection*> track_list = std::get<1>(track_tuple);

--- a/src/REveMu2eMCInterface.cc
+++ b/src/REveMu2eMCInterface.cc
@@ -2,19 +2,18 @@
 using namespace mu2e;
 namespace REX = ROOT::Experimental;
 
-  int REveMu2eMCInterface::Contains(std::vector<int> v, int x)
+ /* int REveMu2eMCInterface::Contains(std::vector<int> v, int x)
   {
     return std::count(v.begin(), v.end(), x);
-  }
+  }*/
  
-  void REveMu2eMCInterface::AddMCTrajectoryCollection(REX::REveManager *&eveMng, bool firstloop,  std::tuple<std::vector<std::string>, std::vector<const MCTrajectoryCollection *>> mctrack_tuple, REX::REveElement* &scene, std::vector<int> particleIds){
-    std::vector<const MCTrajectoryCollection*> track_list = std::get<1>(mctrack_tuple);
-    std::vector<std::string> names = std::get<0>(mctrack_tuple);
+  void REveMu2eMCInterface::AddMCTrajectoryCollection(REX::REveManager *&eveMng, bool firstloop,  const MCTrajectoryCollection *trajcol, REX::REveElement* &scene){
+   
     std::vector<int> colour;
 
-    for(unsigned int j=0; j< track_list.size(); j++){
-      const MCTrajectoryCollection* trajcol = track_list[j];
-      colour.push_back(j+3);
+    //for(unsigned int j=0; j< track_list.size(); j++){
+      //const MCTrajectoryCollection* trajcol = track_list[j];
+      colour.push_back(3);
       if(trajcol!=0){
           std::map<art::Ptr<mu2e::SimParticle>,mu2e::MCTrajectory>::const_iterator trajectoryIter;
           for(unsigned int k = 0; k < trajcol->size(); k++){ 
@@ -23,8 +22,8 @@ namespace REX = ROOT::Experimental;
             { 
 
               //check user defined list of particles to plot:
-              int x = Contains(particleIds,trajectoryIter->first->pdgId()); 
-              if(x == 1){
+              //int x = Contains(particleIds,trajectoryIter->first->pdgId()); 
+             // if(x == 1){
                 const std::vector<MCTrajectoryPoint> &points = trajectoryIter->second.points();
                 std::string energy = std::to_string(points[0].kineticEnergy());
                 const std::string title = " MCTrajectory "+ energy + " Creation code = " + std::to_string(trajectoryIter->first->creationCode()) + "Stopping code = " + std::to_string(trajectoryIter->first->stoppingCode()) + " End Global Time = " + std::to_string(trajectoryIter->first->endGlobalTime())  ;
@@ -42,9 +41,9 @@ namespace REX = ROOT::Experimental;
                 line->SetLineColor(kBlack);
                 line->SetLineWidth(5);
                 scene->AddElement(line); 
-              } else std::cout<<"Warning: No Particles of User-Specified Type In File "<<std::endl;
+              //} else std::cout<<"Warning: No Particles of User-Specified Type In File "<<std::endl;
             }
-          }
+         // }
         }
       }
      }


### PR DESCRIPTION
The following additions and changes have been made :

- The option to include the "Time Cluster" in the display. It can be set in prolog.fcl like the other options.
- The straw hits are colour coded depending on whether they are part of the reconstructed helix. The option to view the colour coded hits is present in prolog.fcl as well. 
- Some modifications have been made with regard to the MC truth display but it is still not completely ready for viewing. 