### PR TITLE
Preparation for art v3_15_00

### DIFF
--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -4,9 +4,12 @@
 //Art:
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Run.h"
+
+#ifndef __ROOTCLING__
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Table.h"
+#endif
 
 #include <TObject.h>
 #include <TROOT.h>
@@ -23,6 +26,7 @@ namespace mu2e{
 	{
       public:
         struct Config{
+#ifndef __ROOTCLING__
           using Name=fhicl::Name;
           using Comment=fhicl::Comment;
           fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("for info"),0};
@@ -48,6 +52,7 @@ namespace mu2e{
           fhicl::Atom<bool> addCosmicTrackSeeds{Name("addCosmicTrackSeeds"), Comment("set to add cosmic track seeds"),false};
           fhicl::Atom<bool> addMCTraj{Name("addMCTraj"), Comment("set to add add MC information"),false};
           fhicl::Atom<bool> FillAll{Name("FillAll"), Comment("to see all available products"), false};
+#endif
         };
 
         explicit CollectionFiller(const Config& conf);

--- a/inc/CollectionFiller.hh
+++ b/inc/CollectionFiller.hh
@@ -4,12 +4,9 @@
 //Art:
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Run.h"
-
-#ifndef __ROOTCLING__
 #include "fhiclcpp/types/Atom.h"
 #include "fhiclcpp/types/Sequence.h"
 #include "fhiclcpp/types/Table.h"
-#endif
 
 #include <TObject.h>
 #include <TROOT.h>
@@ -26,7 +23,6 @@ namespace mu2e{
 	{
       public:
         struct Config{
-#ifndef __ROOTCLING__
           using Name=fhicl::Name;
           using Comment=fhicl::Comment;
           fhicl::Atom<int> diagLevel{Name("diagLevel"), Comment("for info"),0};
@@ -52,7 +48,6 @@ namespace mu2e{
           fhicl::Atom<bool> addCosmicTrackSeeds{Name("addCosmicTrackSeeds"), Comment("set to add cosmic track seeds"),false};
           fhicl::Atom<bool> addMCTraj{Name("addMCTraj"), Comment("set to add add MC information"),false};
           fhicl::Atom<bool> FillAll{Name("FillAll"), Comment("to see all available products"), false};
-#endif
         };
 
         explicit CollectionFiller(const Config& conf);

--- a/inc/DataCollections.hh
+++ b/inc/DataCollections.hh
@@ -13,9 +13,6 @@
 //Art/FCL:
 #include "art/Framework/Principal/Event.h"
 #include "art/Framework/Principal/Run.h"
-#include "fhiclcpp/types/Atom.h"
-#include "fhiclcpp/types/Sequence.h"
-#include "fhiclcpp/types/Table.h"
 
 #include <TObject.h>
 #include <TROOT.h>

--- a/inc/REveMu2eDataInterface.hh
+++ b/inc/REveMu2eDataInterface.hh
@@ -23,7 +23,6 @@
 #include "Offline/RecoDataProducts/inc/CosmicTrackSeed.hh"
 #include "Offline/RecoDataProducts/inc/ComboHit.hh"
 #include "Offline/RecoDataProducts/inc/TimeCluster.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/CalorimeterGeom/inc/CaloGeomUtil.hh"
 #include "Offline/CalorimeterGeom/inc/Calorimeter.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"

--- a/inc/REveMu2eGeomUtil.hh
+++ b/inc/REveMu2eGeomUtil.hh
@@ -4,12 +4,11 @@
 #include <ROOT/REveElement.hxx>
 #include <ROOT/REveManager.hxx>
 
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/StoppingTargetGeom/inc/StoppingTarget.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 
 namespace REX = ROOT::Experimental;
- 
+
 namespace mu2e {
     class REveMu2eGeomUtil  : public REX::REveElement {
 
@@ -20,15 +19,13 @@ namespace mu2e {
             double FindStoppingTarget_z();
             double GetStoppingTarget_z(){ return StoppingTarget_z; }
             double StoppingTarget_z;
-  
+
             #endif
             ClassDef(REveMu2eGeomUtil, 0);
 
 
-    
+
       };
 
 }
 #endif
-
-

--- a/inc/REveMu2eMCInterface.hh
+++ b/inc/REveMu2eMCInterface.hh
@@ -5,7 +5,6 @@
 #include <ROOT/REveManager.hxx>
 #include <ROOT/REveLine.hxx>
 #include <ROOT/REveScene.hxx>
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/GeometryService/inc/DetectorSystem.hh"
 #include "Offline/Mu2eInterfaces/inc/Detector.hh"
 #include "Offline/DataProducts/inc/GenVector.hh"

--- a/inc/REveMu2eMainWindow.hh
+++ b/inc/REveMu2eMainWindow.hh
@@ -44,7 +44,6 @@
 #include "REve/inc/REveMu2eDataInterface.hh"
 #include "REve/inc/REveMu2eMCInterface.hh"
 #include "REve/inc/REveMu2eGeomUtil.hh"
-#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/StoppingTargetGeom/inc/StoppingTarget.hh"
 namespace REX = ROOT::Experimental;
  

--- a/src/REveEventDisplay_module.cc
+++ b/src/REveEventDisplay_module.cc
@@ -72,9 +72,15 @@
 #include "Offline/Mu2eInterfaces/inc/Detector.hh"
 #include "Offline/ConfigTools/inc/ConfigFileLookupPolicy.hh"
 
-using namespace std;
-using namespace mu2e;
 
+// Using declarations for code that might or might not be in ROOT::Experimental
+#if NUMERIC_ROOT_VERION>=6300600
+using ROOT::RWebWindowsManager;
+#else
+using ROOT::Experimental::RWebWindowsManager;
+#endif
+
+using namespace std;
 
 namespace mu2e
 {
@@ -436,7 +442,7 @@ namespace mu2e
 
   void REveEventDisplay::setup_eve()
   {
-      REX::RWebWindowsManager::AssignMainThrd();
+      RWebWindowsManager::AssignMainThrd();
       eveMng_ = REX::REveManager::Create();
       //InitGuiInfo()
       fGui = new REveMu2eGUI();

--- a/src/REveMu2eDataInterface.cc
+++ b/src/REveMu2eDataInterface.cc
@@ -1,5 +1,7 @@
 #include "REve/inc/REveMu2eDataInterface.hh"
 #include "Offline/DataProducts/inc/GenVector.hh"
+#include "Offline/ConfigTools/inc/SimpleConfig.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "Offline/Mu2eKinKal/inc/WireHitState.hh"
 #include "Offline/RecoDataProducts/inc/TrkStrawHitSeed.hh"
 using namespace mu2e;

--- a/src/REveMu2eGeomUtil.cc
+++ b/src/REveMu2eGeomUtil.cc
@@ -1,3 +1,4 @@
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "REve/inc/REveMu2eGeomUtil.hh"
 
 namespace REX = ROOT::Experimental;

--- a/src/REveMu2eMCInterface.cc
+++ b/src/REveMu2eMCInterface.cc
@@ -1,3 +1,5 @@
+#include "Offline/ConfigTools/inc/SimpleConfig.hh"
+#include "Offline/GeometryService/inc/GeomHandle.hh"
 #include "REve/inc/REveMu2eMCInterface.hh"
 using namespace mu2e;
 namespace REX = ROOT::Experimental;

--- a/src/REveMu2eMainWindow.cc
+++ b/src/REveMu2eMainWindow.cc
@@ -1,3 +1,4 @@
+#include "Offline/ConfigTools/inc/SimpleConfig.hh"
 #include "REve/inc/REveMu2eMainWindow.hh"
 
 namespace REX = ROOT::Experimental;

--- a/src/SConscript
+++ b/src/SConscript
@@ -107,7 +107,7 @@ helper.classDef(True)
 
 helper.make_dict_and_map()
 
-mainlib = helper.make_mainlib([userlibs])
+mainlib = helper.make_mainlib([userlibs], [ numeric_root_version ],)
 
 # helper.make_plugins( [ 'mu2e_REveEventDisplay',userlibs ] )
 # Fixme: split into link lists for each module.

--- a/src/SConscript
+++ b/src/SConscript
@@ -9,6 +9,48 @@ Import('mu2e_helper')
 
 helper=mu2e_helper(env)
 
+# Transform the UPS root version into pure numerical form
+# The 4 fields are:
+#   major version number
+#   minor version number
+#   patch number
+#   letter
+# The numerical form is:
+# major*(100**3) + minor*(100**2) + patch*(100) + letter.
+# where letter = 0 if no letter is present, 1 for a, 2 for b etc
+#
+# The alogirthm assumes:
+#  - major and minor version numbers one or two decimal digits, leading zeros optional
+#  - patch number must be 2 digits and requires a leading zero
+#  - letter is a single lowercase letter
+#
+root_version = os.environ['ROOT_VERSION']
+#root_version = os.environ['FOO_VERSION']
+tmp=root_version.replace('v','')
+x=tmp.split('_')
+major=x[0]
+minor=x[1]
+patch=x[2][0:2]
+iletter=0
+
+if len(x[2]) == 3:
+  letter=x[2][2]
+  iletter=ord(letter)-ord('a')+1
+
+elif len(x[2]) == 2:
+  iletter=0
+
+else:
+  print ( 'Aborting building in REve/src/SConscript' )
+  print ( 'Cannot parse ROOT_VERSION: ', root_version )
+  print ( 'Patch field must be 2 or 3 characters long' )
+  Exit(2)
+
+root_v=int(major)*1000000+int(minor)*10000+int(patch)*100+int(iletter)
+
+numeric_root_version='-DNUMERIC_ROOT_VERION='+str(root_v)
+# end of transformation of ROOT_VERSION
+
 babarlibs = env['BABARLIBS']
 rootlibs = env['ROOTLIBS']
 extrarootlibs = [ 'Geom', 'Geom', 'GeomPainter', 'Ged', 'Graf3d', 'Eve','EG', 'RGL','Gui', 'Gdml' , 'Core', 'Rint', 'ROOTEve','ROOTWebDisplay']
@@ -94,7 +136,10 @@ helper.make_plugins( [
     'mu2e_TrkDiag',
     'KinKal_Trajectory',
     'pthread'
-    ] )
+    ],
+     [],
+     [ numeric_root_version ],
+ )
 
 # Fixme: do I need all of babarlibs below?
 helper.make_dict_and_map( [

--- a/src/classes.h
+++ b/src/classes.h
@@ -2,7 +2,6 @@
 #include "REve/inc/REveMu2eDataInterface.hh"
 #include "REve/inc/EventDisplayManager.hh"
 #include "REve/inc/DataCollections.hh"
-#include "REve/inc/CollectionFiller.hh"
 #include "REve/inc/REveMu2eGeomUtil.hh"
 #include "REve/inc/REveMu2eGUI.hh"
 #include "REve/inc/REveMu2eDataProduct.hh"

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -2,7 +2,6 @@
   <class name="mu2e::REveMu2eMainWindow"/>
   <class name="mu2e::REveMu2eDataInterface"/>
   <class name="mu2e::EventDisplayManager"/>
-  <class name="mu2e::DataCollections"/>
   <class name="mu2e::REveMu2eGeomUtil"/>
   <class name="mu2e::REveMu2eGUI"/>
   <class name="mu2e::REveMu2eDataProduct"/>

--- a/src/classes_def.xml
+++ b/src/classes_def.xml
@@ -3,7 +3,6 @@
   <class name="mu2e::REveMu2eDataInterface"/>
   <class name="mu2e::EventDisplayManager"/>
   <class name="mu2e::DataCollections"/>
-  <class name="mu2e::CollectionFiller"/>
   <class name="mu2e::REveMu2eGeomUtil"/>
   <class name="mu2e::REveMu2eGUI"/>
   <class name="mu2e::REveMu2eDataProduct"/>


### PR DESCRIPTION
This PR is a companion to Offline PR 1257.  The two can be merged independently.

Make changes to that are required for art suite v3_15_00 that upgrades root to v6_30_06. The submitted code builds with both the new art suite and the with the current art suite v3_14_03.   I have not yet run-time tested the REve changes.

In most cases the problem was that fhicl code was exposed to dictionary makers because of people having includes that were either unneeded or were in the .hh file rather than the .cc file, where they belonged. I don't understand the details of what in fhicl is causing the problem but there is no reason for fhicl code to be exposed to dictionary makers.

The one special case was  inc/CollectionFiller.hh.  In this case I used `#ifndef __ROOTCLING__` to hide the offending code from root. 

There is one more commit coming about dealing with the movement of some classes from ROOT::Experimental to ROOt:: . I am still working on it and this will be in draft status until it is resolved.  